### PR TITLE
Fixed yellow color shell after FileNotFound Error

### DIFF
--- a/main.py
+++ b/main.py
@@ -79,9 +79,9 @@ if __name__ == "__main__":
     elif args.unsilence:
         print("Not implemented yet")
     else:
-        PrintColors.set_color(PrintColors.OKYELLOW)
         with open(sp_dirs_file) as json_file: # read sharepoint directories to scan
             sp_dirs = json.load(json_file)
+        PrintColors.set_color(PrintColors.OKYELLOW)
         init_local_dirs(sp_dirs)
         username, password = credentials()
 


### PR DESCRIPTION
Spostando il cambio colore dopo il tentativo di apertura del file, in caso non esista, il programma crasha, ma senza diventare giallo